### PR TITLE
adds random test and helper functions for converting coordinates

### DIFF
--- a/cubiomes/Cargo.toml
+++ b/cubiomes/Cargo.toml
@@ -17,3 +17,6 @@ cc_build = ["cubiomes-sys/cc_build"]
 thiserror = "2.0"
 bitflags = "2.0"
 cubiomes-sys = { path = "../cubiomes-sys", version = "0.1.0", default-features = false }
+
+[dev-dependencies]
+rand = "0.9.0"

--- a/cubiomes/src/generator.rs
+++ b/cubiomes/src/generator.rs
@@ -134,10 +134,16 @@ pub enum Scale {
 }
 
 impl Scale {
+    /// Scales a number according to this scale
+    ///
+    /// Divides the input number by the scale
     pub fn scale_coord(&self, num: i32) -> i32 {
         num / *self as i32
     }
 
+    /// Reverses scaling done with this scale
+    ///
+    /// Multiplies the input number with this scale
     pub fn unscale_coord(&self, num: i32) -> i32 {
         num * *self as i32
     }
@@ -203,15 +209,23 @@ impl TryFrom<Range> for cubiomes_sys::Range {
 }
 
 impl Range {
-    pub fn is_inside_range(&self, x: i32, z: i32) -> bool {
+    /// Checks if a given minecraft coordinate is within this range.
+    ///
+    /// First scales and then checks if a given coordinate is within this range.
+    pub fn is_inside(&self, x: i32, z: i32) -> bool {
         ((self.x <= self.scale.scale_coord(x))
             && (self.scale.scale_coord(x) < (self.x + self.size_x as i32)))
             && ((self.z <= self.scale.scale_coord(z))
                 && (self.scale.scale_coord(z) < (self.z + self.size_z as i32)))
     }
 
+    /// Tries to calculate a coordinate relative to this range.
+    ///
+    /// Tries to turn a global minecraft coordinate, to one inside this cache.
+    ///
+    /// Returns none if the coordinate is outside this cache
     pub fn global_to_local_coord(&self, x: i32, z: i32) -> Option<(u32, u32)> {
-        if !self.is_inside_range(x, z) {
+        if !self.is_inside(x, z) {
             None
         } else {
             Some((

--- a/cubiomes/src/lib.rs
+++ b/cubiomes/src/lib.rs
@@ -16,6 +16,7 @@
 #![warn(missing_docs)]
 #![warn(missing_copy_implementations)]
 #![warn(missing_debug_implementations)]
+#![warn(clippy::unwrap_used)]
 
 pub mod generator;
 

--- a/cubiomes/src/tests.rs
+++ b/cubiomes/src/tests.rs
@@ -68,3 +68,32 @@ fn simple_biome_test_cached() -> Result<(), GeneratorError> {
 
     Ok(())
 }
+
+const SOME_RANGE: Range = Range {
+    scale: Scale::Block,
+    x: 0,
+    z: 0,
+    size_x: 32,
+    size_z: 32,
+    y: 320,
+    size_y: 0,
+};
+
+#[test]
+fn test_range_in_bounds() {
+    let range = Range { ..SOME_RANGE };
+    assert!(range.is_inside_range(23, 14));
+}
+
+#[test]
+fn test_range_border_in_bounds() {
+    let range = Range { ..SOME_RANGE };
+    assert!(range.is_inside_range(31, 31));
+}
+
+#[test]
+#[should_panic]
+fn test_range_outside_bounds() {
+    let range = Range { ..SOME_RANGE };
+    assert!(range.is_inside_range(32, 32))
+}

--- a/cubiomes/src/tests.rs
+++ b/cubiomes/src/tests.rs
@@ -82,18 +82,18 @@ const SOME_RANGE: Range = Range {
 #[test]
 fn test_range_in_bounds() {
     let range = Range { ..SOME_RANGE };
-    assert!(range.is_inside_range(23, 14));
+    assert!(range.is_inside(23, 14));
 }
 
 #[test]
 fn test_range_border_in_bounds() {
     let range = Range { ..SOME_RANGE };
-    assert!(range.is_inside_range(31, 31));
+    assert!(range.is_inside(31, 31));
 }
 
 #[test]
 #[should_panic]
 fn test_range_outside_bounds() {
     let range = Range { ..SOME_RANGE };
-    assert!(range.is_inside_range(32, 32))
+    assert!(range.is_inside(32, 32))
 }

--- a/cubiomes/tests/generator.rs
+++ b/cubiomes/tests/generator.rs
@@ -1,0 +1,69 @@
+use cubiomes::{
+    enums::{Dimension, MCVersion},
+    generator::{Generator, GeneratorFlags, Range},
+};
+use rand::{rngs::SmallRng, Rng, SeedableRng};
+
+const SEED: u64 = 937457292385;
+const POINT_AMOUNT: u32 = 100;
+const TEST_Y: i32 = 320;
+const BASE_RANGE: Range = Range {
+    scale: cubiomes::generator::Scale::Block,
+    x: 0,
+    z: 0,
+    size_x: 32,
+    size_z: 32,
+    y: TEST_Y,
+    size_y: 0,
+};
+
+fn get_random_point(rng: &mut (impl SeedableRng + Rng)) -> (i32, i32) {
+    rng.random()
+}
+
+#[test]
+fn test_random_points() {
+    let mut rng = SmallRng::seed_from_u64(SEED);
+
+    for _ in 0..POINT_AMOUNT {
+        let generator = Generator::new(
+            MCVersion::MC_1_21_WD,
+            rng.random(),
+            Dimension::DIM_OVERWORLD,
+            GeneratorFlags::empty(),
+        );
+
+        let (x, z) = get_random_point(&mut rng);
+
+        let biome_get_biome_at = generator.get_biome_at(x, 320, z).unwrap_or_else(|_| {
+            panic!(
+                "Failed to generate biome at x: {}, y: {} z: {}",
+                x, TEST_Y, z
+            )
+        });
+
+        let mut cache = generator.new_cache(Range { x, z, ..BASE_RANGE });
+        cache.fill_cache().unwrap_or_else(|_| {
+            panic!(
+                "Failed to generate cache for range: {:?}",
+                cache.get_range()
+            )
+        });
+
+        let (scaled_x, scaled_z) = cache.get_range().global_to_local_coord(x, z).unwrap();
+
+        dbg!(&scaled_x);
+        dbg!(&scaled_z);
+
+        let biome_get_from_cache = cache
+            .get_biome_at(scaled_x, 0, scaled_z)
+            .unwrap_or_else(|_| {
+                panic!(
+                    "Failed to get biome from cache at x: {}, y: {} z: {}",
+                    x, TEST_Y, z
+                )
+            });
+
+        assert_eq!(biome_get_biome_at, biome_get_from_cache)
+    }
+}


### PR DESCRIPTION
Adds random testing of the genrator and conviniance functions that help with usage

## Changes
- Adds randomized test that tests that many points match between two different ways of generating biomes
- Adds functions to scale coordinates
- Adds functions to convert between minecraft and cache local coordinates
